### PR TITLE
improved handling empty replies

### DIFF
--- a/assets/js/gameLogic.js
+++ b/assets/js/gameLogic.js
@@ -325,22 +325,8 @@ function setRandomPrompt(roundID) {
     let randomCard =
       cardsArray[Math.floor(Math.random() * cardsArray.length)]["text"][0];
     if (randomCard === "") {
-      console.log("[DEBUG] stepped into if statement");
-      $.ajax({
-        url: queryURL,
-        method: "GET"
-      }).then(function(response) {
-        cardsArray = response.calls;
-        randomCard =
-          cardsArray[Math.floor(Math.random() * cardsArray.length)]["text"][0];
-        let cardData = {};
-        cardData["prompt"] = randomCard;
-        writeDataMerge(gameID, roundID, cardData);
-        $(".container").html("");
-        $(".container").html(
-          `<p class = "judge-countdown-holder"> Time Remaining: </p><p class = 'judge-prompt'>${randomCard}</p>`
-        );
-      });
+      setRandomPrompt(roundID);
+      return;
     }
     console.log("[DEBUG] randomCard: " + randomCard);
     let cardData = {};


### PR DESCRIPTION
I was curious about the fix you mentioned earlier and noticed that if the reply is empty the second time the same bug might happen! But since it has to happen twice now we see it way more rarely.

I think we could just call the same function again, which will handle that case too! This way we don't write to HTML and we don't call `countDown` function until we get a non-empty reply, I'm not sure that it aligns with game logic - What do you think?